### PR TITLE
Add light/dark theme toggle with CSS variable-based dark theme

### DIFF
--- a/app/client.ts
+++ b/app/client.ts
@@ -3,6 +3,44 @@ import { APP_VERSION } from "../src/version.js";
 
 createClient();
 
+type ThemeMode = "light" | "dark";
+const THEME_STORAGE_KEY = "kokugo-theme";
+
+function preferredTheme(): ThemeMode {
+  const saved = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (saved === "light" || saved === "dark") {
+    return saved;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: ThemeMode): void {
+  document.documentElement.setAttribute("data-theme", theme);
+
+  const toggleButton = document.getElementById("themeToggle");
+  if (toggleButton) {
+    toggleButton.textContent = theme === "dark" ? "あかるいがめん" : "くらいがめん";
+    toggleButton.setAttribute("aria-pressed", String(theme === "dark"));
+  }
+}
+
+function setupThemeToggle() {
+  const toggleButton = document.getElementById("themeToggle");
+  if (!toggleButton) return;
+
+  let currentTheme = preferredTheme();
+  applyTheme(currentTheme);
+
+  toggleButton.addEventListener("click", () => {
+    currentTheme = currentTheme === "light" ? "dark" : "light";
+    window.localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+    applyTheme(currentTheme);
+  });
+}
+
+setupThemeToggle();
+
 async function setupServiceWorker() {
   if (!("serviceWorker" in navigator)) return;
 

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -40,6 +40,9 @@ export function AppShell({
     <div class={shellClasses.join(" ")}>
       <header class="app-header">
         <p class="app-header-eyebrow">{eyebrow}</p>
+        <button id="themeToggle" class="theme-toggle-btn" type="button" aria-label="がめんのいろをきりかえる">
+          くらいがめん
+        </button>
         <h1 class="app-header-title">{title}</h1>
         <p class="app-header-subtitle">{subtitle}</p>
       </header>

--- a/app/style.css
+++ b/app/style.css
@@ -19,6 +19,38 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg: #d4e4ed;
+  --bg-light: #e8f0f5;
+  --card: #f5f0e8;
+  --sidebar: #c8dce8;
+  --mint: #9ec5a0;
+  --pink: #e8a0aa;
+  --yellow: #e8d88c;
+  --text: #3a3a3a;
+  --text-sub: #7a7a7a;
+  --border: #b8c8d4;
+  --outline: #4a4a4a;
+  --header-sub: #6c7c88;
+  --surface-glass: rgba(232, 240, 245, 0.96);
+}
+
+[data-theme="dark"] {
+  --bg: #1c242d;
+  --bg-light: #253341;
+  --card: #2c3744;
+  --sidebar: #23303d;
+  --mint: #8fcb94;
+  --pink: #e29ba6;
+  --yellow: #d9c778;
+  --text: #e5ebf0;
+  --text-sub: #b7c2cc;
+  --border: #425567;
+  --outline: #edf2f6;
+  --header-sub: #c4d0da;
+  --surface-glass: rgba(37, 51, 65, 0.95);
+}
+
 html,
 body {
   height: 100%;
@@ -26,8 +58,8 @@ body {
 
 body {
   font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", "Meiryo", system-ui, sans-serif;
-  background: #d4e4ed;
-  color: #3a3a3a;
+  background: var(--bg);
+  color: var(--text);
   min-height: 100vh;
   overflow: hidden;
 }
@@ -44,10 +76,10 @@ body {
 
 .app-header {
   padding: 1rem 1.5rem 0.9rem;
-  border-bottom: 1px solid #b8c8d4;
+  border-bottom: 1px solid var(--border);
   background:
     radial-gradient(circle at top left, rgba(232, 160, 170, 0.18), transparent 38%),
-    linear-gradient(180deg, rgba(232, 240, 245, 0.95), rgba(212, 228, 237, 0.92));
+    linear-gradient(180deg, color-mix(in srgb, var(--bg-light) 95%, transparent), color-mix(in srgb, var(--bg) 92%, transparent));
   text-align: center;
   flex-shrink: 0;
 }
@@ -55,19 +87,35 @@ body {
 .app-header-eyebrow {
   font-size: 0.82rem;
   letter-spacing: 0.08em;
-  color: #7a7a7a;
+  color: var(--text-sub);
   margin-bottom: 0.3rem;
 }
 
 .app-header-title {
   font-size: clamp(1.5rem, 3vw, 2.2rem);
-  color: #9ec5a0;
+  color: var(--mint);
   margin-bottom: 0.35rem;
 }
 
 .app-header-subtitle {
   font-size: 0.95rem;
-  color: #6c7c88;
+  color: var(--header-sub);
+}
+
+.theme-toggle-btn {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-light);
+  color: var(--text);
+  font-size: 0.78rem;
+  line-height: 1.2;
+  padding: 0.35rem 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.theme-toggle-btn:hover {
+  background: var(--mint);
+  color: #fff;
 }
 
 /* App layout: sidebar + main */
@@ -80,8 +128,8 @@ body {
 .sidebar {
   width: 320px;
   min-width: 320px;
-  background: #c8dce8;
-  border-right: 1px solid #b8c8d4;
+  background: var(--sidebar);
+  border-right: 1px solid var(--border);
   padding: 1rem;
   overflow-y: auto;
   min-height: 0;
@@ -99,7 +147,7 @@ body {
   text-align: center;
   font-size: 1rem;
   margin-bottom: 0.9rem;
-  color: #6c7c88;
+  color: var(--header-sub);
   letter-spacing: 0.06em;
 }
 
@@ -119,23 +167,23 @@ body {
   justify-content: center;
   padding: 0.3rem 0.6rem;
   font-size: 0.85rem;
-  border: 2px solid #b8c8d4;
+  border: 2px solid var(--border);
   border-radius: 6px;
-  background: #e8f0f5;
-  color: #3a3a3a;
+  background: var(--bg-light);
+  color: var(--text);
   cursor: pointer;
   text-decoration: none;
   transition: all 0.2s;
 }
 
 .grade-btn:hover {
-  border-color: #9ec5a0;
+  border-color: var(--mint);
   color: #6a9a6e;
 }
 
 .grade-btn.active {
   background: #9ec5a0;
-  border-color: #9ec5a0;
+  border-color: var(--mint);
   color: white;
 }
 
@@ -148,19 +196,19 @@ body {
   justify-content: center;
   margin-bottom: 1rem;
   padding: 0.5rem;
-  background: #e8f0f5;
+  background: var(--bg-light);
   border-radius: 8px;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
 }
 
 .kanji-grid-btn {
   width: 36px;
   height: 36px;
   font-size: 1.1rem;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
   border-radius: 4px;
-  background: #f5f0e8;
-  color: #3a3a3a;
+  background: var(--card);
+  color: var(--text);
   cursor: pointer;
   transition: all 0.15s;
   padding: 0;
@@ -208,16 +256,16 @@ body {
   margin-top: -8px;
   margin-left: -8px;
   border: 2px solid rgba(184, 200, 212, 0.9);
-  border-top-color: #9ec5a0;
+  border-top-color: var(--mint);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
 
 .kanji-grid-btn.is-loading,
 .kanji-grid-btn.is-loading:hover {
-  background: #f5f0e8;
-  border-color: #9ec5a0;
-  color: #3a3a3a;
+  background: var(--card);
+  border-color: var(--mint);
+  color: var(--text);
 }
 
 .kanji-grid-btn.is-error {
@@ -239,9 +287,9 @@ body {
 
 .kanji-grid-btn.active.is-loading,
 .kanji-grid-btn.active.is-loading:hover {
-  background: #f5f0e8;
-  border-color: #9ec5a0;
-  color: #3a3a3a;
+  background: var(--card);
+  border-color: var(--mint);
+  color: var(--text);
 }
 
 /* Input */
@@ -273,7 +321,7 @@ body {
   width: 30vmin;
   height: 30vmin;
   border: 10px solid #b8c8d4;
-  border-top-color: #9ec5a0;
+  border-top-color: var(--mint);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -289,7 +337,7 @@ body {
   justify-content: center;
   min-height: min(52vh, 420px);
   padding: 1.5rem;
-  color: #7a7a7a;
+  color: var(--text-sub);
   font-size: 1.2rem;
   text-align: center;
 }
@@ -299,15 +347,15 @@ body {
   padding: 0.4rem 0.5rem;
   width: 40%;
   text-align: center;
-  border: 2px solid #b8c8d4;
+  border: 2px solid var(--border);
   border-radius: 8px;
-  background: #f5f0e8;
-  color: #3a3a3a;
+  background: var(--card);
+  color: var(--text);
   outline: none;
 }
 
 #kanjiInput:focus {
-  border-color: #9ec5a0;
+  border-color: var(--mint);
 }
 
 button {
@@ -343,8 +391,8 @@ button:hover {
 .section h3 {
   font-size: 1rem;
   margin-bottom: 0.5rem;
-  color: #7a7a7a;
-  border-bottom: 1px solid #b8c8d4;
+  color: var(--text-sub);
+  border-bottom: 1px solid var(--border);
   padding-bottom: 0.3rem;
 }
 
@@ -447,16 +495,16 @@ button:hover {
   width: 100%;
   padding: 0.5rem;
   font-size: 0.9rem;
-  background: #e8f0f5;
-  border: 1px solid #b8c8d4;
+  background: var(--bg-light);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: #4a4a4a;
+  color: var(--outline);
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .sidebar-toggle:hover {
-  background: #d4e4ed;
+  background: var(--bg);
 }
 
 /* Readings */
@@ -468,21 +516,21 @@ button:hover {
 }
 
 .reading-group {
-  background: #f5f0e8;
+  background: var(--card);
   border-radius: 8px;
   padding: 0.4rem 0.8rem;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
 }
 
 .reading-group .label {
   font-size: 0.65rem;
-  color: #7a7a7a;
+  color: var(--text-sub);
   margin-bottom: 0.2rem;
 }
 
 .reading-group .values {
   font-size: 1rem;
-  color: #3a3a3a;
+  color: var(--text);
 }
 
 .reading-group .values span {
@@ -498,10 +546,10 @@ button:hover {
 }
 
 .step-card {
-  background: #f5f0e8;
+  background: var(--card);
   border-radius: 6px;
   padding: 0.25rem;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
 }
 
 .step-card-preview {
@@ -512,7 +560,7 @@ button:hover {
 
 .step-card .step-label {
   font-size: 0.6rem;
-  color: #7a7a7a;
+  color: var(--text-sub);
   margin-top: 0.1rem;
   text-align: center;
 }
@@ -548,17 +596,17 @@ button:hover {
 }
 
 .word-card {
-  background: #f5f0e8;
+  background: var(--card);
   border-radius: 8px;
   padding: 0.35rem 0.7rem;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
   text-align: center;
   min-width: 70px;
 }
 
 .word-card .word {
   font-size: 1.1rem;
-  color: #3a3a3a;
+  color: var(--text);
 }
 
 .word-card .word-reading {
@@ -576,9 +624,9 @@ button:hover {
 }
 
 .animation-canvas {
-  background: #f5f0e8;
+  background: var(--card);
   border-radius: 8px;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
   padding: 0.5rem;
   display: inline-block;
 }
@@ -608,9 +656,9 @@ button:hover {
   padding: 0.35rem 0.6rem;
   font-size: 0.8rem;
   border-radius: 6px;
-  background: #e8f0f5;
-  border: 1px solid #b8c8d4;
-  color: #4a4a4a;
+  background: var(--bg-light);
+  border: 1px solid var(--border);
+  color: var(--outline);
   cursor: pointer;
   transition: all 0.2s;
   margin-top: 0.4rem;
@@ -618,7 +666,7 @@ button:hover {
 
 .mode-toggle-btn:hover {
   background: #9ec5a0;
-  border-color: #9ec5a0;
+  border-color: var(--mint);
   color: white;
 }
 
@@ -633,9 +681,9 @@ button:hover {
 }
 
 .trace-canvas {
-  background: #f5f0e8;
+  background: var(--card);
   border-radius: 8px;
-  border: 2px solid #b8c8d4;
+  border: 2px solid var(--border);
   padding: 0.5rem;
   display: inline-block;
   touch-action: none;
@@ -663,7 +711,7 @@ button:hover {
 
 .trace-counter {
   font-size: 0.9rem;
-  color: #7a7a7a;
+  color: var(--text-sub);
 }
 
 .trace-ending-hint {
@@ -728,9 +776,9 @@ button:hover {
   padding: 0.3rem 0.8rem;
   font-size: 0.8rem;
   border-radius: 6px;
-  background: #f5f0e8;
+  background: var(--card);
   border: 1px solid #9ec5a0;
-  color: #3a3a3a;
+  color: var(--text);
   font-weight: 600;
 }
 
@@ -753,7 +801,7 @@ button:hover {
 
 .trace-message {
   font-size: 1.2rem;
-  color: #9ec5a0;
+  color: var(--mint);
   font-weight: bold;
   text-align: left;
   width: 100%;
@@ -780,16 +828,16 @@ button:hover {
   align-items: center;
   gap: 0.4rem;
   font-size: 0.9rem;
-  color: #7a7a7a;
+  color: var(--text-sub);
 }
 
 .practice-options input[type="number"] {
   width: 50px;
   padding: 0.3rem;
-  background: #f5f0e8;
-  border: 1px solid #b8c8d4;
+  background: var(--card);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: #3a3a3a;
+  color: var(--text);
   text-align: center;
 }
 
@@ -801,7 +849,7 @@ button:hover {
 
 .print-view-note {
   text-align: center;
-  color: #6c7c88;
+  color: var(--header-sub);
 }
 
 .print-view-sheet-wrap {
@@ -813,7 +861,7 @@ button:hover {
 .print-preview-sheet {
   width: min(100%, 1100px);
   background: white;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
   border-radius: 18px;
   box-shadow: 0 10px 28px rgba(58, 58, 58, 0.12);
   overflow: hidden;
@@ -835,8 +883,8 @@ button:hover {
 }
 
 .data-info-card {
-  background: #f5f0e8;
-  border: 1px solid #b8c8d4;
+  background: var(--card);
+  border: 1px solid var(--border);
   border-radius: 18px;
   padding: 1.1rem 1.2rem;
   box-shadow: 0 8px 20px rgba(58, 58, 58, 0.06);
@@ -844,7 +892,7 @@ button:hover {
 
 .data-info-card h2,
 .data-info-card h3 {
-  color: #6c7c88;
+  color: var(--header-sub);
   margin-bottom: 0.5rem;
 }
 
@@ -858,7 +906,7 @@ button:hover {
 
 .data-info-card p {
   line-height: 1.7;
-  color: #4a4a4a;
+  color: var(--outline);
 }
 
 .data-info-card p + p {
@@ -868,7 +916,7 @@ button:hover {
 .data-info-list {
   margin-top: 0.25rem;
   padding-left: 1.2rem;
-  color: #4a4a4a;
+  color: var(--outline);
 }
 
 .data-info-list li {
@@ -900,8 +948,8 @@ button:hover {
   position: sticky;
   bottom: 0;
   z-index: 4;
-  border-top: 1px solid #b8c8d4;
-  background: rgba(232, 240, 245, 0.96);
+  border-top: 1px solid var(--border);
+  background: var(--surface-glass);
   backdrop-filter: blur(8px);
   padding: 0.9rem 1rem;
   box-shadow: 0 -8px 18px rgba(58, 58, 58, 0.06);
@@ -937,7 +985,7 @@ button:hover {
   padding: 0;
   font-size: 0.82rem;
   line-height: 1.4;
-  color: #6c7c88;
+  color: var(--header-sub);
   text-decoration: underline;
   text-underline-offset: 0.16em;
   cursor: pointer;
@@ -948,7 +996,7 @@ button:hover {
 }
 
 .app-footer-meta-link.is-active {
-  color: #4a4a4a;
+  color: var(--outline);
   font-weight: 600;
   text-decoration: none;
   cursor: default;
@@ -963,23 +1011,23 @@ button:hover {
   align-items: center;
   justify-content: center;
   min-width: 124px;
-  border: 1px solid #b8c8d4;
+  border: 1px solid var(--border);
   border-radius: 999px;
   padding: 0.75rem 1.25rem;
   font-size: 0.95rem;
-  background: #f5f0e8;
-  color: #4a4a4a;
+  background: var(--card);
+  color: var(--outline);
   text-decoration: none;
 }
 
 .app-footer-btn:hover {
-  background: #e8f0f5;
-  color: #4a4a4a;
+  background: var(--bg-light);
+  color: var(--outline);
 }
 
 .app-footer-btn.is-primary {
   background: #9ec5a0;
-  border-color: #9ec5a0;
+  border-color: var(--mint);
   color: white;
 }
 
@@ -998,7 +1046,7 @@ button:hover {
 }
 
 .app-footer-btn.is-secondary {
-  background: #e8f0f5;
+  background: var(--bg-light);
 }
 
 .app-footer-btn:disabled {
@@ -1020,7 +1068,7 @@ button:hover {
     min-width: 100%;
     min-height: auto;
     border-right: none;
-    border-bottom: 1px solid #b8c8d4;
+    border-bottom: 1px solid var(--border);
   }
 
   .sidebar-content.collapsed {


### PR DESCRIPTION
### Motivation
- Provide a kid-friendly light/dark screen option so the app is easier to use in low-light and to match user preferences while keeping labels in hiragana for children.
- Make color theming maintainable by replacing many hard-coded colors with CSS custom properties and a dark-theme override.

### Description
- Add a header toggle button (`themeToggle`) to the app shell so users can switch modes (labelled `くらいがめん` / `あかるいがめん`, `aria-label` in hiragana). (`app/components/AppShell.tsx`)
- Implement client-side theme logic that reads/writes a persistent preference under `localStorage` key `kokugo-theme`, falls back to `prefers-color-scheme`, applies the theme by setting `data-theme` on `<html>`, and updates the toggle button state/label (`app/client.ts`).
- Refactor `app/style.css` to use CSS custom properties for the core palette, add a `[data-theme="dark"]` override block, and update component styles to consume the variables; include styles for the theme toggle button and ensure surface/contrast adjustments for dark mode. (`app/style.css`)

### Testing
- Ran `bun test` which failed in this environment due to `import.meta.glob` being unavailable (server harness mismatch), producing an environment error. (failed)
- Ran the project test script `bun run test` (executes `vitest run`), and the test suite passed: `1 file, 2 tests` all green. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea07ceb6d083228d89753bcff11048)